### PR TITLE
fix: trim SKILL.md description to 590 chars + README v4.0.2 rework (closes #9)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "cybersecurity-pro",
       "description": "Professional cybersecurity skill: 22 domains covering IR, DFIR, DevSecOps, SOC+SOAR, GitOps, Code Security, Container/Supply Chain, Threat Modeling, Compliance Frameworks, Cloud Security & CSPM, Zero Trust Architecture, AI/ML Security, API Security, Vulnerability Management, Threat Intelligence, Cross-Domain Integration, Security Governance & Executive Leadership, OT/ICS Security, Agentic AI Security, Post-Quantum Cryptography, Identity & Access Security, Web3 & Blockchain Security. Bilingual Thai+English output.",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "author": {
         "name": "P.Itarun"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cybersecurity-pro",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Professional cybersecurity skill: 22 domains covering IR, DFIR, DevSecOps, SOC+SOAR, GitOps, Code Security, Container/Supply Chain, Threat Modeling, Compliance Frameworks, Cloud Security & CSPM, Zero Trust Architecture, AI/ML Security, API Security, Vulnerability Management, Threat Intelligence, Cross-Domain Integration, Security Governance & Executive Leadership, OT/ICS Security, Agentic AI Security, Post-Quantum Cryptography, Identity & Access Security, and Web3 & Blockchain Security. Bilingual Thai+English output.",
   "author": {
     "name": "P.Itarun"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.2] - 2026-05-12
+
+### Fixed
+
+- **SKILL.md description trimmed from ~4,663 → 590 characters** (#9) — within Anthropic spec cap (1024) and Claude Code per-entry cap (`skillListingMaxDescChars` = 1536). Eliminates `/doctor` warning, silent truncation of trailing trigger keywords, and ~15k tokens/session overhead for users who raised the cap. Full trigger keyword list (15 categories) moved to the skill body under "When This Skill Activates / เมื่อใดที่สกิลนี้ทำงาน" — Claude reads the body once the skill is invoked.
+
+### Changed
+
+- README.md rework — improved structure (TOC, NIST CSF coverage map, Frameworks badge, Related Plugins, Support table), Thai/English consistency pass, version bump to 4.0.2
+
 ## [4.0.0] - 2026-02-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 **Enterprise Cybersecurity Skill for Claude Code**
 
-สร้างเอกสาร Cybersecurity ระดับมืออาชีพใน 30 วินาที — IR Playbooks, SOC Procedures,
-Compliance Audits, Cloud Security, AI Governance, OT/ICS Security และอีก 16 domains
-พร้อม output แบบ bilingual Thai + English ที่ map กับ NIST, MITRE ATT&CK, OWASP, ISO frameworks
+Generate professional cybersecurity documents in 30 seconds — IR Playbooks, DFIR Reports,
+SOC Procedures, Compliance Audits, Cloud Security, AI Governance, OT/ICS, Post-Quantum Crypto,
+and 14 more domains — bilingual Thai + English output mapped to NIST, MITRE ATT&CK, OWASP, ISO frameworks
 
-[![Version](https://img.shields.io/badge/version-4.0.1-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-4.0.2-blue.svg)](CHANGELOG.md)
 [![CI](https://github.com/pitimon/claude-cybersecurity-skill/actions/workflows/validate.yml/badge.svg)](https://github.com/pitimon/claude-cybersecurity-skill/actions/workflows/validate.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Domains](https://img.shields.io/badge/domains-22-orange.svg)](#capabilities-ความสามารถ--22-domains)
-[![Language](https://img.shields.io/badge/language-Thai%20%2B%20English-blueviolet.svg)](#bilingual-output-policy)
+[![Domains](https://img.shields.io/badge/domains-22-orange.svg)](#-22-security-domains)
+[![Frameworks](https://img.shields.io/badge/frameworks-73-brightgreen.svg)](#-frameworks--standards-73-references)
 
 </div>
 
@@ -20,16 +20,34 @@ Compliance Audits, Cloud Security, AI Governance, OT/ICS Security และอ�
 
 <div align="center">
 
-**22 Domains** | **73 Frameworks** | **< 8% Context Budget**
-
-ครอบคลุม 22 security domains ตั้งแต่ Incident Response ถึง Web3 & Blockchain Security —
-map กับ 73 international frameworks — ใช้ context เพียง ~7,000-15,000 tokens ต่อ request (< 8% ของ 200K window)
+**22 Domains** &nbsp;|&nbsp; **73 Frameworks** &nbsp;|&nbsp; **< 8% Context Budget** &nbsp;|&nbsp; **Bilingual TH+EN**
 
 </div>
 
 ---
 
-## See It in Action (ลองใช้ใน 30 วินาที)
+## Table of Contents
+
+- [See It in Action](#-see-it-in-action)
+- [Quick Start](#-quick-start)
+- [Why This Plugin](#-why-this-plugin)
+- [What's New in v4.0.2](#-whats-new-in-v402)
+- [22 Security Domains](#-22-security-domains)
+- [NIST CSF 2.0 Coverage Map](#-nist-csf-20-coverage-map)
+- [Usage Examples](#-usage-examples)
+- [How It Works](#-how-it-works)
+- [Frameworks & Standards](#-frameworks--standards-73-references)
+- [Comparison](#-comparison)
+- [Repository Structure](#-repository-structure)
+- [Plugin Details](#-plugin-details)
+- [Contributing](#-contributing)
+- [Related Plugins](#-related-plugins)
+- [Support](#-support)
+- [License](#license)
+
+---
+
+## See It in Action
 
 พิมพ์ prompt เดียว — ได้ IR playbook ระดับ enterprise ทันที:
 
@@ -58,8 +76,6 @@ map กับ 73 international frameworks — ใช้ context เพียง 
 | ----------- | ------------------ | -------------------- | ------------------------- |
 | P1-Critical | ≤ 15 min           | ≤ 1 hour             | ≤ 4 hours                 |
 
-...
-
 ### Escalation Matrix
 
 | Level | Role        | Trigger Condition | MITRE ATT&CK           |
@@ -69,15 +85,15 @@ map กับ 73 international frameworks — ใช้ context เพียง 
 ...
 ```
 
-ไม่ต้อง prompt engineer เอง — templates map กับ NIST 800-61, MITRE ATT&CK, ISO 27035 ให้อัตโนมัติ
+Templates map กับ NIST 800-61, MITRE ATT&CK, ISO 27035 อัตโนมัติ — ไม่ต้อง prompt engineer เอง
 
 ---
 
-## Quick Start (เริ่มต้นใช้งาน)
+## Quick Start
 
-### Step 1: ติดตั้ง — รันใน Terminal Shell
+### Step 1: ติดตั้ง
 
-เปิด **terminal** (ไม่ใช่ใน Claude Code prompt) แล้วรันคำสั่งทั้ง 3 ตามลำดับ:
+เปิด **terminal** (ไม่ใช่ใน Claude Code prompt) แล้วรันคำสั่งทั้ง 3:
 
 ```bash
 # 1. เพิ่ม marketplace
@@ -91,15 +107,15 @@ claude doctor
 # Expected: ✓ cybersecurity-pro@pitimon-cybersecurity - OK
 ```
 
-### Step 2: เริ่มใช้งาน — พิมพ์ใน Claude Code Prompt
+### Step 2: เริ่มใช้งาน
 
-เปิด **Claude Code session ใหม่** (หรือพิมพ์ `/clear` เพื่อ reload skills) แล้วพิมพ์:
+เปิด **Claude Code session ใหม่** (หรือ `/clear`) แล้วพิมพ์:
 
 ```
 > สร้าง IR playbook สำหรับ ransomware incident ตาม NIST 800-61
 ```
 
-Skill จะถูก trigger อัตโนมัติเมื่อ prompt ตรงกับ keywords ของ domain ใด domain หนึ่ง — ไม่ต้องเรียก skill ด้วยตัวเอง
+Skill จะ trigger อัตโนมัติเมื่อ prompt ตรงกับ keywords ของ domain — ไม่ต้องเรียก skill ด้วยตัวเอง
 
 ### อัพเดท Plugin
 
@@ -110,22 +126,107 @@ claude doctor  # ตรวจสอบ version ใหม่
 # Restart Claude Code session เพื่อโหลด skill version ใหม่
 ```
 
-> ดูคู่มือฉบับเต็ม: [docs/INSTALL.md](docs/INSTALL.md) | สำหรับ air-gapped server ดู Manual Installation
+> คู่มือฉบับเต็ม: [docs/INSTALL.md](docs/INSTALL.md) &nbsp;|&nbsp; แก้ปัญหา: [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)
 
 ---
 
-## Why This Plugin (ทำไมต้องใช้ Plugin นี้)
+## Why This Plugin
 
 **Problem**: Claude Code เป็น general-purpose AI — ไม่มี cybersecurity domain expertise built-in ทำให้ต้องเขียน prompt ละเอียดทุกครั้ง และผลลัพธ์ไม่สม่ำเสมอ
 
-**Solution**: `cybersecurity-pro` โหลด professional templates และ framework mappings อัตโนมัติเมื่อ prompt ตรง trigger keywords
+**Solution**: `cybersecurity-pro` โหลด professional templates + framework mappings อัตโนมัติเมื่อ prompt ตรง trigger keywords
 
-### Value Propositions
+|                       | Without Plugin     | With cybersecurity-pro                  |
+| --------------------- | ------------------ | --------------------------------------- |
+| **Output quality**    | ขึ้นอยู่กับ prompt | Enterprise-grade templates ทุกครั้ง     |
+| **Framework mapping** | ต้อง research เอง  | Auto-mapped 73 frameworks               |
+| **Bilingual TH+EN**   | ต้องสั่งทุกครั้ง   | Built-in — Thai prose, English terms    |
+| **Thai compliance**   | ต้องหาข้อมูลเอง    | พ.ร.บ. ไซเบอร์ / PDPA / ก.ล.ต. included |
+| **SLA / Escalation**  | ต้องออกแบบเอง      | Templates พร้อม severity-based SLA      |
+| **MITRE ATT&CK IDs**  | ต้องค้นเอง         | Auto-mapped ทุก attack scenario         |
+| **Context cost**      | Variable           | < 8% ของ 200K window                    |
 
-- **Enterprise-quality output ทันที** — Templates ออกแบบโดย security professionals พร้อม SLA, escalation, RACI matrices ในตัว ไม่ต้อง prompt engineer เอง
-- **Framework-mapped templates** — ทุก output map กับ frameworks จริง (NIST, MITRE ATT&CK, OWASP, ISO 27001, CIS) — ไม่ต้องตรวจสอบความถูกต้องของ references เอง
-- **Bilingual Thai + English** — พร้อมใช้ในองค์กรไทย รองรับ พ.ร.บ. การรักษาความมั่นคงปลอดภัยไซเบอร์ พ.ศ. 2562 และ PDPA ใน compliance templates
-- **On-demand loading — ไม่กิน context** — มี 22 domains แต่โหลดแค่ 1 ต่อ request ใช้ context < 8% ของ 200K window
+---
+
+## What's New in v4.0.2
+
+**v4.0.2** — Issue #6 Enhancements (6 items)
+
+- **Quick Reference sections** — เพิ่มตาราง summary สำหรับ D19-D22 ให้เข้าใจ domain ได้ภายใน 30 วินาที
+- **PQC ↔ Web3 cross-domain linkage** — ECDSA vulnerability timeline, 4-phase blockchain migration path, Ethereum EIP-7702
+- **Real-world attack scenarios (D19)** — 4 scenarios พร้อม MITRE ATLAS + OWASP Agentic mapping และ detection templates (Splunk SPL + KQL)
+- **IdP configuration templates (D21)** — Entra ID Conditional Access, Okta FIDO2 (Terraform), AWS IAM Identity Center SCIM
+- **Thai Context deepening** — D20: CNSA 2.0 CII sector timeline, D21: PromptPay identity binding, D22: ก.ล.ต. regulatory updates 2025-2026
+- **frameworks.json** expanded 69 → 73 entries (FIDO2/WebAuthn, SPIFFE, OAuth 2.1, Ethereum Security BP)
+
+**v4.0.0** — Major Release (4 new domains + 11 enhancements)
+
+- 4 new domains: Agentic AI Security (D19), Post-Quantum Cryptography (D20), Identity & Access Security (D21), Web3 & Blockchain Security (D22)
+- Enhanced: NIST Cyber AI Profile in D12, NIST LEV metric in D14, CWE Top 25 (2025) in D6, Compliance Cross-Walk Matrix in D9, Cyber Resilience Metrics in D17
+- Guided decision tree fallback + template variables ({ORG_NAME}, {DATE}, {INDUSTRY}, {ANALYST_NAME})
+
+> ดู changelog ฉบับเต็ม: [CHANGELOG.md](CHANGELOG.md)
+
+---
+
+## 22 Security Domains
+
+### Security Operations
+
+| #   | Domain                      | คำอธิบาย                                                                | Key Frameworks               |
+| --- | --------------------------- | ----------------------------------------------------------------------- | ---------------------------- |
+| D1  | **IR Playbooks & Runbooks** | Incident response playbooks พร้อม SLA, escalation matrix, post-mortem   | NIST 800-61, ISO 27035       |
+| D2  | **DFIR Reports**            | Forensic reports พร้อม chain of custody, evidence handling, timeline    | NIST 800-86, IOC             |
+| D4  | **SOC Operations + SOAR**   | SOC L1-L3 procedures, SIEM rules, SOAR automation, threat hunting       | MITRE ATT&CK, Kill Chain     |
+| D15 | **Threat Intelligence**     | TI program, STIX/TAXII integration, IOC lifecycle, intelligence sharing | STIX 2.1, TAXII 2.1, TLP 2.0 |
+
+### Secure Development & AppSec
+
+| #   | Domain                       | คำอธิบาย                                                                | Key Frameworks             |
+| --- | ---------------------------- | ----------------------------------------------------------------------- | -------------------------- |
+| D3  | **DevSecOps Pipeline**       | CI/CD security pipeline สำหรับ GitHub Actions / GitLab CI               | OWASP SAMM, NIST SSDF      |
+| D6  | **Code Security Analysis**   | Static analysis — Semgrep/CodeQL, SARIF, variant analysis               | CWE Top 25, SARIF 2.1.0    |
+| D7  | **Container & Supply Chain** | Container hardening, vulnerability scanning, SBOM, image signing        | NIST 800-190, SLSA         |
+| D13 | **API Security**             | OWASP API Top 10, JWT, OAuth 2.0 BCP, API gateway security              | OWASP API Top 10, RFC 9700 |
+| D14 | **Vulnerability Management** | Vulnerability lifecycle, CVSS/EPSS/KEV prioritization, patch management | CVSS v4.0, EPSS, CISA KEV  |
+
+### Governance, Risk & Compliance
+
+| #   | Domain                     | คำอธิบาย                                                                | Key Frameworks              |
+| --- | -------------------------- | ----------------------------------------------------------------------- | --------------------------- |
+| D5  | **GitOps Security**        | Policy-as-code สำหรับ ArgoCD, OPA/Gatekeeper, Falco                     | OPA, Gatekeeper, Falco      |
+| D8  | **Threat Modeling & Risk** | STRIDE/PASTA threat modeling, risk assessment, risk matrix              | STRIDE, PASTA, ISO 27001    |
+| D9  | **Compliance Frameworks**  | Gap analysis, control mappings, compliance roadmaps                     | NIST 800-53, PCI DSS v4.0.1 |
+| D17 | **Security Governance**    | Executive governance, board reporting, maturity models, CISO/CAIO roles | NIST CSF 2.0 GOVERN, C2M2   |
+
+### Cloud, Architecture & Identity
+
+| #   | Domain                         | คำอธิบาย                                                  | Key Frameworks              |
+| --- | ------------------------------ | --------------------------------------------------------- | --------------------------- |
+| D10 | **Cloud Security & CSPM**      | Cloud audits, IAM reviews, CSPM configs (AWS/Azure/GCP)   | CIS Cloud, CSA CCM v4.1     |
+| D11 | **Zero Trust Architecture**    | ZTA maturity, implementation roadmaps, microsegmentation  | NIST 800-207, CISA ZT       |
+| D21 | **Identity & Access Security** | FIDO2/Passkeys, ITDR, NHI management, identity governance | NIST 800-63B, FIDO2, SPIFFE |
+
+### AI & Emerging Technology
+
+| #   | Domain                         | คำอธิบาย                                                              | Key Frameworks                  |
+| --- | ------------------------------ | --------------------------------------------------------------------- | ------------------------------- |
+| D12 | **AI/ML Security**             | AI security assessments, LLM guardrails, AI red team, AI governance   | OWASP LLM Top 10, NIST AI RMF   |
+| D19 | **Agentic AI Security**        | Agent threat modeling, tool-use guardrails, multi-agent orchestration | OWASP Agentic Top 10 2026       |
+| D20 | **Post-Quantum Cryptography**  | PQC migration roadmaps, hybrid key exchange, crypto-agility           | NIST FIPS 203/204/205, CNSA 2.0 |
+| D22 | **Web3 & Blockchain Security** | Smart contract audits, DeFi security, wallet/bridge security          | OWASP SC Top 10 2026            |
+
+### Industrial & OT
+
+| #   | Domain              | คำอธิบาย                                                       | Key Frameworks         |
+| --- | ------------------- | -------------------------------------------------------------- | ---------------------- |
+| D18 | **OT/ICS Security** | OT assessments, Purdue Model segmentation, SCADA/PLC hardening | NIST 800-82, IEC 62443 |
+
+### Cross-Domain
+
+| #   | Domain                       | คำอธิบาย                                                                  | Key Frameworks |
+| --- | ---------------------------- | ------------------------------------------------------------------------- | -------------- |
+| D16 | **Cross-Domain Integration** | End-to-end security workflows, SOAR orchestration, multi-domain scenarios | NIST CSF 2.0   |
 
 ---
 
@@ -134,183 +235,149 @@ claude doctor  # ตรวจสอบ version ใหม่
 22 domains ครอบคลุมทุก function ของ NIST Cybersecurity Framework 2.0:
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                      NIST CSF 2.0 FUNCTIONS                     │
-├────────────┬────────────────────────────────────────────────────┤
-│            │                                                    │
-│  GOVERN    │  D17 Security Governance & Executive Leadership    │
-│            │                                                    │
-├────────────┼────────────────────────────────────────────────────┤
-│            │  D8  Threat Modeling & Risk                        │
-│  IDENTIFY  │  D9  Compliance Frameworks                        │
-│            │  D14 Vulnerability Management                      │
-│            │  D15 Threat Intelligence                           │
-│            │  D18 OT/ICS Security (OT asset management)        │
-│            │  D21 Identity & Access Security                    │
-├────────────┼────────────────────────────────────────────────────┤
-│            │  D3  DevSecOps Pipeline                            │
-│            │  D5  GitOps Security                               │
-│            │  D6  Code Security Analysis                        │
-│  PROTECT   │  D7  Container & Supply Chain                     │
-│            │  D10 Cloud Security & CSPM                         │
-│            │  D11 Zero Trust Architecture                       │
-│            │  D12 AI/ML Security                                │
-│            │  D13 API Security                                  │
-│            │  D18 OT/ICS Security (OT network protection)      │
-│            │  D19 Agentic AI Security                           │
-│            │  D20 Post-Quantum Cryptography                     │
-│            │  D21 Identity & Access Security                    │
-│            │  D22 Web3 & Blockchain Security                    │
-├────────────┼────────────────────────────────────────────────────┤
-│  DETECT    │  D4  SOC Operations + SOAR                        │
-│            │  D15 Threat Intelligence                           │
-│            │  D19 Agentic AI Security                           │
-│            │  D22 Web3 & Blockchain Security                    │
-├────────────┼────────────────────────────────────────────────────┤
-│  RESPOND   │  D1  IR Playbooks & Runbooks                      │
-│            │  D2  DFIR Reports                                  │
-├────────────┼────────────────────────────────────────────────────┤
-│  RECOVER   │  D1  IR Playbooks (post-mortem & lessons learned)  │
-│            │  D14 Vulnerability Management (remediation)        │
-├────────────┼────────────────────────────────────────────────────┤
-│            │                                                    │
-│  CROSS-    │  D16 Cross-Domain Integration Scenarios            │
-│  DOMAIN    │  (orchestrates all domains via SOAR & workflows)   │
-│            │                                                    │
-└────────────┴────────────────────────────────────────────────────┘
+┌────────────┬──────────────────────────────────────────────────────────┐
+│  GOVERN    │  D17 Security Governance & Executive Leadership         │
+├────────────┼──────────────────────────────────────────────────────────┤
+│            │  D8  Threat Modeling & Risk    D14 Vulnerability Mgmt   │
+│  IDENTIFY  │  D9  Compliance Frameworks    D15 Threat Intelligence   │
+│            │  D18 OT/ICS (asset mgmt)      D21 Identity & Access     │
+├────────────┼──────────────────────────────────────────────────────────┤
+│            │  D3  DevSecOps    D5  GitOps     D6  Code Security      │
+│            │  D7  Container    D10 Cloud      D11 Zero Trust         │
+│  PROTECT   │  D12 AI/ML       D13 API        D18 OT/ICS (network)   │
+│            │  D19 Agentic AI   D20 PQC       D21 Identity & Access   │
+│            │  D22 Web3 & Blockchain                                  │
+├────────────┼──────────────────────────────────────────────────────────┤
+│  DETECT    │  D4  SOC + SOAR   D15 Threat Intelligence               │
+│            │  D19 Agentic AI   D22 Web3 & Blockchain                 │
+├────────────┼──────────────────────────────────────────────────────────┤
+│  RESPOND   │  D1  IR Playbooks & Runbooks   D2  DFIR Reports         │
+├────────────┼──────────────────────────────────────────────────────────┤
+│  RECOVER   │  D1  IR Playbooks (post-mortem)  D14 Vuln Mgmt (fix)    │
+├────────────┼──────────────────────────────────────────────────────────┤
+│  CROSS-    │  D16 Cross-Domain Integration Scenarios                 │
+│  DOMAIN    │  (orchestrates all domains via SOAR & workflows)        │
+└────────────┴──────────────────────────────────────────────────────────┘
 ```
 
 ---
 
-## Capabilities (ความสามารถ — 22 Domains)
+## Usage Examples
+
+ตัวอย่าง prompt ใน Claude Code — skill trigger อัตโนมัติจาก keywords:
 
 ### Security Operations
-
-| Domain                           | คำอธิบาย                                                                           | Frameworks                         |
-| -------------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------- |
-| **D1 — IR Playbooks & Runbooks** | Incident response playbooks พร้อม SLA, escalation matrix, post-mortem templates    | NIST SP 800-61, ISO 27035, SANS IR |
-| **D2 — DFIR Reports**            | Forensic investigation reports พร้อม chain of custody, evidence handling, timeline | Chain of Custody, IOC, Timeline    |
-| **D4 — SOC Operations + SOAR**   | SOC L1-L3 procedures, SIEM rules, SOAR automation playbooks, threat hunting        | MITRE ATT&CK, Cyber Kill Chain     |
-
-### Secure Development
-
-| Domain                             | คำอธิบาย                                                                | Frameworks                        |
-| ---------------------------------- | ----------------------------------------------------------------------- | --------------------------------- |
-| **D3 — DevSecOps Pipeline**        | CI/CD security pipeline configs สำหรับ GitHub Actions / GitLab CI       | OWASP SAMM, OWASP Top 10, CIS     |
-| **D6 — Code Security Analysis**    | Static analysis ด้วย Semgrep/CodeQL, SARIF processing, variant analysis | CWE Top 25, SARIF 2.1.0           |
-| **D7 — Container & Supply Chain**  | Container hardening, vulnerability scanning, SBOM, image signing        | NIST SP 800-190, CIS Docker, SLSA |
-| **D13 — API Security**             | OWASP API Top 10, JWT validation, OAuth 2.0 BCP, API gateway security   | OWASP API Top 10 2023, RFC 9700   |
-| **D14 — Vulnerability Management** | Vulnerability lifecycle, CVSS/EPSS/KEV prioritization, patch management | CVSS v4.0, EPSS, CISA KEV, SSVC   |
-
-### Governance & Compliance
-
-| Domain                          | คำอธิบาย                                                                      | Frameworks                                         |
-| ------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------- |
-| **D5 — GitOps Security**        | Policy-as-code frameworks สำหรับ ArgoCD, OPA, Falco                           | OPA/Gatekeeper, Falco, ArgoCD                      |
-| **D8 — Threat Modeling & Risk** | STRIDE/PASTA threat modeling, risk assessment, SOC 2/ISO 27001                | SOC 2, ISO 27001, STRIDE, PASTA, PDPA              |
-| **D9 — Compliance Frameworks**  | Compliance assessments, gap analyses, control mappings                        | NIST 800-53, PCI DSS v4.0.1, GDPR, HIPAA, CIS v8.1 |
-| **D17 — Security Governance**   | Executive governance, board reporting, maturity models, CISO/CAIO/CAISO roles | NIST CSF 2.0 GOVERN, ISO 27014, C2M2               |
-
-### Cloud & Architecture
-
-| Domain                               | คำอธิบาย                                                                   | Frameworks                                          |
-| ------------------------------------ | -------------------------------------------------------------------------- | --------------------------------------------------- |
-| **D10 — Cloud Security & CSPM**      | Cloud security audits, IAM reviews, CSPM configs (AWS/Azure/GCP)           | CIS Cloud Benchmarks, CSA CCM v4.1, NIST 800-144    |
-| **D11 — Zero Trust Architecture**    | ZTA maturity assessments, implementation roadmaps, microsegmentation       | NIST 800-207, CISA ZT Maturity Model, Forrester ZTX |
-| **D12 — AI/ML Security**             | AI security assessments, LLM guardrails, AI red team, AI governance        | OWASP LLM Top 10, NIST AI RMF, MITRE ATLAS          |
-| **D19 — Agentic AI Security**        | Agentic AI threat modeling, tool-use guardrails, multi-agent orchestration | OWASP Agentic Top 10 2026, MITRE ATLAS 2025         |
-| **D20 — Post-Quantum Cryptography**  | PQC migration roadmaps, hybrid key exchange, crypto-agility assessments    | NIST FIPS 203/204/205, CNSA 2.0, NIST IR 8547       |
-| **D21 — Identity & Access Security** | IAM maturity assessments, FIDO2/passkeys, ITDR, identity governance        | NIST 800-63B, FIDO2, NIST IR 8587, SPIFFE           |
-
-### Industrial & OT
-
-| Domain                    | คำอธิบาย                                                                    | Frameworks                                        |
-| ------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------- |
-| **D18 — OT/ICS Security** | OT/ICS security assessments, Purdue Model segmentation, SCADA/PLC hardening | NIST SP 800-82 Rev.3, IEC 62443, MITRE ATT&CK ICS |
-
-### Web3 & Blockchain
-
-| Domain                               | คำอธิบาย                                                                   | Frameworks                       |
-| ------------------------------------ | -------------------------------------------------------------------------- | -------------------------------- |
-| **D22 — Web3 & Blockchain Security** | Smart contract audits, DeFi security, on-chain monitoring, wallet security | OWASP Smart Contract Top 10 2026 |
-
-### Intelligence & Integration
-
-| Domain                             | คำอธิบาย                                                                       | Frameworks                                  |
-| ---------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------- |
-| **D15 — Threat Intelligence**      | TI program design, STIX/TAXII integration, IOC lifecycle, intelligence sharing | STIX 2.1, TAXII 2.1, TLP 2.0, Diamond Model |
-| **D16 — Cross-Domain Integration** | End-to-end security workflows, SOAR orchestration, multi-domain scenarios      | NIST CSF 2.0, All domain frameworks         |
-
----
-
-## Usage Examples (ตัวอย่างการใช้งาน)
-
-ตัวอย่าง prompt ที่พิมพ์ **ใน Claude Code** — skill จะ trigger อัตโนมัติจาก keywords
-
-### IR Playbook
 
 ```
 > สร้าง IR playbook สำหรับ ransomware incident ตาม NIST 800-61
   รวม escalation matrix และ SLA timelines
 ```
 
-### SOC + SOAR
-
 ```
 > สร้าง SOAR playbook สำหรับ automated phishing response
   รวม enrichment sources และ containment actions
 ```
 
-### Compliance
+### Compliance & Governance
 
 ```
 > สร้าง NIST 800-53 gap assessment สำหรับ cloud environment
   พร้อม PCI DSS v4.0.1 control mapping และ CIS Controls roadmap
 ```
 
-### Cloud Security
+```
+> สร้าง security governance framework ตาม NIST CSF 2.0 GOVERN
+  พร้อม board reporting template และ CISO/CAIO RACI matrix
+```
+
+### Cloud & Architecture
 
 ```
 > ทำ cloud security audit สำหรับ AWS environment
   ตรวจสอบ IAM policies, S3 buckets, Security Groups ตาม CIS Benchmarks
 ```
 
-### AI/ML Security
+```
+> สร้าง Zero Trust implementation roadmap ตาม NIST 800-207
+  รวม maturity assessment และ microsegmentation plan
+```
+
+<details>
+<summary><strong>ดูตัวอย่างเพิ่มเติมทั้ง 22 domains</strong></summary>
+
+### AI & Emerging Technology
 
 ```
 > สร้าง AI security assessment สำหรับ LLM application
   ตรวจสอบ prompt injection defense และ OWASP LLM Top 10 compliance
 ```
 
-### Security Governance
-
 ```
-> สร้าง security governance framework ตาม NIST CSF 2.0 GOVERN
-  พร้อม board reporting template, CISO/CAIO/CAISO RACI matrix, และ C2M2 maturity assessment
+> สร้าง agentic AI security checklist ตาม OWASP Agentic Top 10 2026
+  รวม agent permission models, memory security และ multi-agent orchestration controls
 ```
 
-<details>
-<summary>ดูตัวอย่างเพิ่มเติมทั้ง 22 domains →</summary>
-
-### DFIR Report
-
 ```
-> สร้างแม่แบบ DFIR report สำหรับ memory forensics investigation
-  ต้องมี chain of custody form และ evidence handling procedures
+> สร้าง crypto-agility assessment สำหรับ PQC migration ตาม CNSA 2.0
+  รวม NIST FIPS 203/204/205 readiness checklist และ hybrid key exchange roadmap
 ```
 
-### Code Security Analysis
+```
+> สร้าง smart contract security audit checklist ตาม OWASP Smart Contract Top 10 2026
+  รวม Solidity code analysis, DeFi security patterns และ audit methodology
+```
+
+### Identity & Access
+
+```
+> สร้าง identity security assessment ตาม NIST 800-63B Rev 4
+  รวม FIDO2/Passkeys rollout plan, NHI management และ ITDR program design
+```
+
+### Secure Development
 
 ```
 > สร้าง Semgrep custom rules สำหรับตรวจจับ SQL injection ด้วย taint mode
   พร้อม GitHub Actions pipeline ที่รวม CodeQL
 ```
 
-### Container Security
-
 ```
 > สร้าง Dockerfile hardening guide สำหรับ Node.js application
   รวม Trivy scanning, SBOM generation, และ cosign signing
+```
+
+```
+> สร้าง API security assessment ตาม OWASP API Top 10
+  ตรวจสอบ BOLA, JWT validation, rate limiting พร้อม API gateway config
+```
+
+```
+> สร้าง vulnerability management program พร้อม CVSS+EPSS+KEV prioritization
+  รวม SLA templates, patch management workflow, และ executive dashboard
+```
+
+### DFIR & Threat Intelligence
+
+```
+> สร้างแม่แบบ DFIR report สำหรับ memory forensics investigation
+  ต้องมี chain of custody form และ evidence handling procedures
+```
+
+```
+> สร้าง threat intelligence program ด้วย STIX/TAXII integration
+  รวม MISP setup, IOC lifecycle management, และ TLP 2.0 sharing procedures
+```
+
+### Industrial & Cross-Domain
+
+```
+> สร้าง OT security assessment ตาม NIST 800-82 และ IEC 62443
+  รวม Purdue Model network segmentation design และ PLC hardening checklist
+```
+
+```
+> ออกแบบ end-to-end security workflow ตั้งแต่ threat intelligence ถึง incident response
+  พร้อม SOAR orchestration template และ cross-domain metrics dashboard
 ```
 
 ### Threat Modeling
@@ -320,135 +387,49 @@ claude doctor  # ตรวจสอบ version ใหม่
   รวม risk matrix และ SOC 2 compliance mapping
 ```
 
-### Zero Trust
-
-```
-> สร้าง Zero Trust implementation roadmap ตาม NIST 800-207
-  รวม maturity assessment และ microsegmentation plan
-```
-
-### API Security
-
-```
-> สร้าง API security assessment ตาม OWASP API Top 10
-  ตรวจสอบ BOLA, JWT validation, rate limiting พร้อม API gateway config
-```
-
-### Vulnerability Management
-
-```
-> สร้าง vulnerability management program พร้อม CVSS+EPSS+KEV prioritization
-  รวม SLA templates, patch management workflow, และ executive dashboard
-```
-
-### Threat Intelligence
-
-```
-> สร้าง threat intelligence program ด้วย STIX/TAXII integration
-  รวม MISP setup, IOC lifecycle management, และ TLP 2.0 sharing procedures
-```
-
-### Cross-Domain Integration
-
-```
-> ออกแบบ end-to-end security workflow ตั้งแต่ threat intelligence ถึง incident response
-  พร้อม SOAR orchestration template และ cross-domain metrics dashboard
-```
-
-### OT/ICS Security
-
-```
-> สร้าง OT security assessment ตาม NIST 800-82 และ IEC 62443
-  รวม Purdue Model network segmentation design และ PLC hardening checklist
-```
-
-### Agentic AI Security
-
-```
-> สร้าง agentic AI security checklist ตาม OWASP Agentic Top 10 2026
-  รวม agent permission models, memory security และ multi-agent orchestration controls
-```
-
-### Post-Quantum Cryptography
-
-```
-> สร้าง crypto-agility assessment สำหรับ PQC migration ตาม CNSA 2.0
-  รวม NIST FIPS 203/204/205 readiness checklist และ hybrid key exchange roadmap
-```
-
-### Identity & Access Security
-
-```
-> สร้าง identity security assessment ตาม NIST 800-63B Rev 4
-  รวม FIDO2/Passkeys rollout plan, NHI management และ ITDR program design
-```
-
-### Web3 & Blockchain Security
-
-```
-> สร้าง smart contract security audit checklist ตาม OWASP Smart Contract Top 10 2026
-  รวม Solidity code analysis, DeFi security patterns และ audit methodology
-```
-
 </details>
 
 ---
 
-## Architecture & Token Budget (สถาปัตยกรรมและงบ Token)
+## How It Works
 
-### How It Works
+### Architecture
 
 ```
-User prompt → keyword match in SKILL.md frontmatter
+User prompt → keyword match in SKILL.md
   → SKILL.md loaded (~5,000 tokens: language policy, frameworks, decision tree)
-  → Decision tree selects domain
+  → Decision tree routes to 1 of 22 domains
   → Corresponding references/*.md loaded on-demand (~2,000-10,000 tokens)
-  → Output generated following templates in reference file
+  → Output generated following domain templates + framework mappings
 ```
 
 ### Token Budget
 
-**On-demand loading**: มี 22 domains แต่โหลดแค่ 1 ต่อ request
+**On-demand loading** — มี 22 domains แต่โหลดแค่ 1 ต่อ request:
 
-| Component                | Tokens            | หมายเหตุ                              |
-| ------------------------ | ----------------- | ------------------------------------- |
-| SKILL.md (always loaded) | ~5,000            | Router + language policy + frameworks |
-| Reference file (1 of 22) | ~2,000-10,000     | โหลดเฉพาะ domain ที่ trigger          |
-| **Per request**          | **~7,000-15,000** | **< 8% ของ 200K context window**      |
-| Total all files          | ~120,000          | ไม่โหลดทั้งหมดพร้อมกัน                |
+| Component                 | Tokens            | หมายเหตุ                              |
+| ------------------------- | ----------------- | ------------------------------------- |
+| SKILL.md (always loaded)  | ~5,000            | Router + language policy + frameworks |
+| Reference file (1 of 22)  | ~2,000-10,000     | โหลดเฉพาะ domain ที่ trigger          |
+| **Per request total**     | **~7,000-15,000** | **< 8% ของ 200K context window**      |
+| Total all reference files | ~120,000          | ไม่โหลดทั้งหมดพร้อมกัน                |
 
-### Skill Engineering Techniques
+### Design Principles
 
-เทคนิคที่ใช้ออกแบบ plugin นี้ — เป็นแนวทางสำหรับผู้ที่ต้องการสร้าง Claude Code skill ของตัวเอง:
-
-1. **On-demand reference loading** — โหลดเฉพาะ domain ที่ user ต้องการ เพิ่ม domains ได้โดยไม่เพิ่ม base context cost (ปัจจุบัน 22 domains)
+1. **On-demand reference loading** — เพิ่ม domains ได้โดยไม่เพิ่ม base context cost
 2. **Composite reference files** — รวม topics ที่เกี่ยวข้องเป็นไฟล์เดียว (เช่น Semgrep + CodeQL + SARIF → `code-security-analysis.md`)
-3. **Framework-first templates** — Templates map กับ framework controls (NIST, MITRE ATT&CK IDs, CWE) ทำให้ output มี reference ที่ถูกต้อง
-4. **Bilingual output policy** — Thai prose + English terms ใน output เดียว ไม่ต้องสร้าง 2 versions
-5. **SKILL.md as compact router** — Decision tree ใน ~500 lines ทำหน้าที่เป็น lightweight router
+3. **Framework-first templates** — ทุก output map กับ framework controls จริง (NIST, MITRE ATT&CK, CWE)
+4. **Bilingual output policy** — Thai prose + English terms ใน output เดียว
+5. **SKILL.md as compact router** — Decision tree ~500 lines เป็น lightweight router ให้ 22 domains
 
 ---
 
-## Comparison (เปรียบเทียบ)
+## Frameworks & Standards (73 References)
 
-| Aspect                 | Manual Prompting  | cybersecurity-pro              | Enterprise Tools |
-| ---------------------- | ----------------- | ------------------------------ | ---------------- |
-| **Setup time**         | 0                 | 3 commands, 30 sec             | Weeks-months     |
-| **Framework mapping**  | Manual research   | Auto-mapped (73 frameworks)    | Vendor-specific  |
-| **Bilingual TH+EN**    | DIY every time    | Built-in policy                | Limited/none     |
-| **Thai compliance**    | Must research     | พ.ร.บ. ไซเบอร์ / PDPA included | Varies           |
-| **Output consistency** | Varies per prompt | Standardized templates         | Standardized     |
-| **Context overhead**   | Variable          | < 8% (7,000-15,000 tokens)     | N/A              |
-| **Cost**               | Free              | Free (MIT)                     | $$$$             |
-| **Maintenance**        | Manual updates    | Community-maintained           | Vendor-dependent |
+Outputs อ้างอิง 73 frameworks จัดกลุ่มตาม audience:
 
----
-
-## Frameworks & Standards
-
-Outputs อ้างอิง frameworks เหล่านี้ตามความเหมาะสม — จัดกลุ่มตาม audience:
-
-### SOC / IR Teams
+<details>
+<summary><strong>SOC / IR Teams</strong></summary>
 
 - **MITRE ATT&CK** / **MITRE D3FEND** — Tactic & technique mapping
 - **NIST SP 800-61 Rev.2** — Incident response lifecycle
@@ -456,15 +437,21 @@ Outputs อ้างอิง frameworks เหล่านี้ตามคว
 - **Cyber Kill Chain** — Attack phase analysis
 - **Diamond Model** — Intrusion analysis
 
-### DevSecOps / AppSec
+</details>
+
+<details>
+<summary><strong>DevSecOps / AppSec</strong></summary>
 
 - **OWASP Top 10** / **OWASP SAMM** — Application security
-- **OWASP API Security Top 10** — API vulnerability risks
-- **CWE Top 25** / **SARIF 2.1.0** — Code vulnerability classification
+- **OWASP API Security Top 10 2023** — API vulnerability risks
+- **CWE Top 25 (2025)** / **SARIF 2.1.0** — Code vulnerability classification
 - **CIS Docker Benchmark** / **SLSA** — Container & supply chain
 - **NIST SP 800-190** — Container security
 
-### Compliance / GRC
+</details>
+
+<details>
+<summary><strong>Compliance / GRC</strong></summary>
 
 - **NIST SP 800-53 Rev 5** — Security & privacy controls
 - **PCI DSS v4.0.1** — Payment card industry
@@ -473,115 +460,156 @@ Outputs อ้างอิง frameworks เหล่านี้ตามคว
 - **SOC 2** / **ISO 27001:2022** — Information security management
 - **พ.ร.บ. ไซเบอร์ 2562** / **PDPA** — Thai cybersecurity & data privacy law
 
-### Executive / Governance
+</details>
+
+<details>
+<summary><strong>Executive / Governance</strong></summary>
 
 - **NIST CSF 2.0** — Cybersecurity framework (GOVERN function)
 - **ISO 27014:2020** — Information security governance
 - **C2M2** — Cybersecurity capability maturity model
 - **SEC Cybersecurity Rules** — Disclosure requirements
 
-### Cloud / Zero Trust
+</details>
+
+<details>
+<summary><strong>Cloud / Zero Trust</strong></summary>
 
 - **CIS Cloud Benchmarks** / **CSA CCM v4.1** — Cloud security posture
 - **NIST SP 800-207** — Zero Trust Architecture
 - **CISA Zero Trust Maturity Model** — ZTA implementation
 - **NIST SP 800-144** — Cloud computing guidelines
 
-### AI Security
+</details>
+
+<details>
+<summary><strong>AI & Agentic AI Security</strong></summary>
 
 - **OWASP Top 10 for LLM Apps** — AI/LLM application security
-- **NIST AI RMF** / **MITRE ATLAS** — AI risk management & threats
+- **OWASP Agentic Top 10 2026** — Agentic AI-specific risks
+- **NIST AI RMF** / **MITRE ATLAS 2025** — AI risk management & threats
 - **EU AI Act** / **ISO 42001** — AI governance & regulation
 
-### AI Agent Security Engineers
+</details>
 
-- **OWASP Agentic Top 10 2026** — Agentic AI-specific vulnerability risks
-- **MITRE ATLAS 2025** — AI adversarial threat landscape (agent extensions)
-
-### Post-Quantum / Cryptography
+<details>
+<summary><strong>Post-Quantum / Cryptography</strong></summary>
 
 - **NIST FIPS 203/204/205** — ML-KEM, ML-DSA, SLH-DSA post-quantum standards
 - **CNSA 2.0** — NSA Commercial National Security Algorithm Suite
 - **NIST IR 8547** — Transition to post-quantum cryptography standards
 
-### Identity & Access
+</details>
+
+<details>
+<summary><strong>Identity & Access</strong></summary>
 
 - **NIST SP 800-63B** — Digital identity guidelines (authentication)
 - **FIDO2 / WebAuthn** — Passwordless authentication standards
 - **NIST IR 8587** — Identity threat detection & response
 - **SPIFFE / SPIRE** — Workload identity framework
+- **OAuth 2.1** — Authorization framework
 
-### Web3/Blockchain Developers
+</details>
+
+<details>
+<summary><strong>Web3 / Blockchain</strong></summary>
 
 - **OWASP Smart Contract Top 10 2026** — Smart contract vulnerability risks
+- **Ethereum Security Best Practices** — Smart contract development security
 
-### Industrial / OT
+</details>
+
+<details>
+<summary><strong>Industrial / OT</strong></summary>
 
 - **NIST SP 800-82 Rev.3** — OT/ICS security guide
-- **IEC 62443** (ISA/IEC) — Industrial automation and control system security
+- **IEC 62443** — Industrial automation and control system security
 - **Purdue Model / ISA-95** — OT network segmentation architecture
 - **MITRE ATT&CK for ICS** — ICS-specific tactics, techniques, and procedures
 - **NERC CIP** — North American electric grid reliability standards
 
-### Threat Intelligence
+</details>
+
+<details>
+<summary><strong>Threat Intelligence / Vulnerability</strong></summary>
 
 - **STIX 2.1** / **TAXII 2.1** — Threat information expression & sharing
 - **Traffic Light Protocol 2.0** — Intelligence sharing classification
 - **CVSS v4.0** / **EPSS** — Vulnerability scoring & exploit prediction
 - **CISA KEV** / **SSVC** — Known exploited vulnerabilities & prioritization
 
+</details>
+
+> ดูรายละเอียด version tracking: [`frameworks.json`](frameworks.json) (73 entries with grep patterns + staleness tracking)
+
 ---
 
-## Repository Structure (โครงสร้าง Repository)
+## Comparison
+
+| Aspect                 | Manual Prompting     | cybersecurity-pro              | Enterprise Tools |
+| ---------------------- | -------------------- | ------------------------------ | ---------------- |
+| **Setup time**         | 0                    | 3 commands, 30 sec             | Weeks-months     |
+| **Framework mapping**  | Manual research      | Auto-mapped (73 frameworks)    | Vendor-specific  |
+| **Bilingual TH+EN**    | DIY every time       | Built-in policy                | Limited/none     |
+| **Thai compliance**    | Must research        | พ.ร.บ. ไซเบอร์ / PDPA / ก.ล.ต. | Varies           |
+| **Output consistency** | Varies per prompt    | Standardized templates         | Standardized     |
+| **Context overhead**   | Variable             | < 8% (7K-15K tokens)           | N/A              |
+| **Cost**               | Free                 | Free (MIT)                     | $$$$             |
+| **Domains**            | Unlimited (no depth) | 22 deep domains                | Vendor-dependent |
+| **Maintenance**        | Manual updates       | Community + quarterly review   | Vendor-dependent |
+
+---
+
+## Repository Structure
 
 ```
 claude-cybersecurity-skill/
 ├── .claude-plugin/
-│   ├── marketplace.json          # Marketplace metadata
-│   └── plugin.json               # Plugin metadata (v4.0.1)
+│   ├── marketplace.json              # Marketplace metadata
+│   └── plugin.json                   # Plugin manifest (v4.0.2)
 ├── skills/
 │   └── cybersecurity-pro/
-│       ├── SKILL.md              # Skill definition & decision tree
-│       └── references/
-│           ├── ir-playbooks.md              # IR playbook + post-mortem templates
-│           ├── dfir-reports.md              # Forensic report templates
-│           ├── devsecops-pipeline.md        # CI/CD security configs
-│           ├── soc-operations.md            # SOC L1-L3 + SOAR automation
-│           ├── gitops-security.md           # GitOps security policies
-│           ├── code-security-analysis.md    # Semgrep/CodeQL/SARIF/Variant
-│           ├── container-supply-chain.md    # Container hardening/SBOM/signing
-│           ├── compliance-threat-modeling.md # STRIDE/PASTA/Risk/SOC2/ISO27001
-│           ├── compliance-frameworks.md     # NIST 800-53/PCI DSS/GDPR/HIPAA/CIS
-│           ├── cloud-security-cspm.md       # Cloud Security/IAM/CSPM/Multi-cloud
-│           ├── zero-trust-architecture.md   # ZTA/NIST 800-207/Microsegmentation
-│           ├── ai-ml-security.md            # AI/ML/LLM Security/MITRE ATLAS
-│           ├── api-security.md              # OWASP API Top 10/JWT/OAuth/Gateway
-│           ├── vulnerability-management.md  # CVSS/EPSS/KEV/Patch Management
-│           ├── threat-intelligence.md       # STIX/TAXII/IOC/TLP/MISP/OpenCTI
-│           ├── cross-domain-integration.md  # End-to-end workflows/orchestration
-│           ├── security-governance-executive.md # CISO/CAIO/CAISO/Board/Maturity
-│           ├── ot-ics-security.md           # OT/ICS/SCADA/Purdue/IEC 62443
-│           ├── agentic-ai-security.md       # Agentic AI/Tool-use/Multi-agent
-│           ├── post-quantum-cryptography.md # PQC/FIPS 203-205/CNSA 2.0
-│           ├── identity-access-security.md  # IAM/FIDO2/ITDR/SPIFFE
-│           └── web3-blockchain-security.md  # Smart Contract/DeFi/Web3
-├── frameworks.json                # Framework version manifest (73 entries)
+│       ├── SKILL.md                  # Skill definition & decision tree (~500 lines)
+│       └── references/              # Domain reference files (22 files)
+│           ├── ir-playbooks.md              # D1  IR playbook + post-mortem
+│           ├── dfir-reports.md              # D2  Forensic report templates
+│           ├── devsecops-pipeline.md        # D3  CI/CD security configs
+│           ├── soc-operations.md            # D4  SOC L1-L3 + SOAR
+│           ├── gitops-security.md           # D5  GitOps security policies
+│           ├── code-security-analysis.md    # D6  Semgrep/CodeQL/SARIF
+│           ├── container-supply-chain.md    # D7  Container/SBOM/signing
+│           ├── compliance-threat-modeling.md # D8  STRIDE/PASTA/Risk
+│           ├── compliance-frameworks.md     # D9  NIST 800-53/PCI/GDPR/HIPAA
+│           ├── cloud-security-cspm.md       # D10 Cloud/IAM/CSPM
+│           ├── zero-trust-architecture.md   # D11 ZTA/NIST 800-207
+│           ├── ai-ml-security.md            # D12 AI/ML/LLM Security
+│           ├── api-security.md              # D13 OWASP API/JWT/OAuth
+│           ├── vulnerability-management.md  # D14 CVSS/EPSS/KEV/Patch
+│           ├── threat-intelligence.md       # D15 STIX/TAXII/IOC/MISP
+│           ├── cross-domain-integration.md  # D16 End-to-end workflows
+│           ├── security-governance-executive.md # D17 CISO/Board/Maturity
+│           ├── ot-ics-security.md           # D18 OT/ICS/SCADA/Purdue
+│           ├── agentic-ai-security.md       # D19 Agentic AI/Multi-agent
+│           ├── post-quantum-cryptography.md # D20 PQC/FIPS 203-205
+│           ├── identity-access-security.md  # D21 IAM/FIDO2/ITDR
+│           └── web3-blockchain-security.md  # D22 Smart Contract/DeFi
+├── frameworks.json                   # Framework version manifest (73 entries)
 ├── docs/
-│   ├── INSTALL.md                 # Installation guide
-│   ├── TROUBLESHOOTING.md         # Troubleshooting guide
-│   ├── FRAMEWORK-UPDATE-RUNBOOK.md # Framework update procedures
-│   └── MANDAY-ESTIMATION.md       # Man-day cost estimation (63 days WBS)
+│   ├── INSTALL.md                    # Installation guide
+│   ├── TROUBLESHOOTING.md            # Troubleshooting guide
+│   ├── FRAMEWORK-UPDATE-RUNBOOK.md   # Framework update procedures
+│   └── MANDAY-ESTIMATION.md          # Man-day cost estimation
 ├── tests/
-│   ├── validate-plugin.sh         # Structural validation (68 checks)
-│   ├── check-framework-updates.sh # Ad-hoc framework staleness checker
-│   └── smoke-test-prompts.md      # Manual functional tests (23 scenarios)
-├── .github/
-│   └── workflows/
-│       ├── validate.yml          # CI on push/PR
-│       └── framework-review.yml  # Quarterly framework review
-├── CHANGELOG.md                  # Version history
-├── CLAUDE.md                     # Claude Code guidance
-└── README.md                     # This file
+│   ├── validate-plugin.sh            # Structural validation (68 checks)
+│   ├── check-framework-updates.sh    # Framework staleness checker
+│   └── smoke-test-prompts.md         # Manual functional tests (23 scenarios)
+├── .github/workflows/
+│   ├── validate.yml                  # CI on push/PR
+│   └── framework-review.yml         # Quarterly framework review
+├── CHANGELOG.md
+├── CLAUDE.md
+└── README.md                         # This file
 ```
 
 ---
@@ -593,11 +621,13 @@ claude-cybersecurity-skill/
 | **Plugin name** | `cybersecurity-pro`                       |
 | **Marketplace** | `pitimon-cybersecurity`                   |
 | **Install key** | `cybersecurity-pro@pitimon-cybersecurity` |
-| **Version**     | 4.0.1                                     |
+| **Version**     | 4.0.2                                     |
 | **Category**    | Security                                  |
 | **Author**      | P.Itarun                                  |
 | **Language**    | Bilingual Thai + English                  |
 | **Domains**     | 22                                        |
+| **Frameworks**  | 73                                        |
+| **License**     | MIT                                       |
 
 ---
 
@@ -611,16 +641,45 @@ claude-cybersecurity-skill/
 
 ### เพิ่ม Domain ใหม่
 
-1. สร้างไฟล์ `skills/cybersecurity-pro/references/<domain-name>.md`
+1. สร้างไฟล์ `skills/cybersecurity-pro/references/<domain-name>.md` ตามรูปแบบ reference files ที่มีอยู่
 2. อัพเดท `SKILL.md` — เพิ่ม domain entry + trigger keywords + decision tree branch
-3. อัพเดท `README.md` — เพิ่มใน capabilities table
+3. อัพเดท `README.md` — เพิ่มใน domain table + usage examples
 4. อัพเดท `CLAUDE.md` — เพิ่มใน domain table
 5. เพิ่ม entry ใน `CHANGELOG.md`
 6. หาก domain มี versioned frameworks ใหม่ — เพิ่ม entries ใน `frameworks.json` พร้อม grep patterns และ used_in file lists
+7. รัน `bash tests/validate-plugin.sh --skip-install-check` เพื่อตรวจสอบ
 
 ---
 
-## Troubleshooting (แก้ไขปัญหา)
+## Related Plugins
+
+| Plugin                                                            | คำอธิบาย                                                                                                           | Install                                                 |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
+| **[shannon-pentest](https://github.com/pitimon/shannon-pentest)** | Autonomous penetration testing orchestrator — configure targets, launch scans, monitor workflows, analyze findings | `claude plugin install shannon-pentest@pitimon-shannon` |
+
+**Complementary workflow**:
+
+```
+Shannon (offensive)                    cybersecurity-pro (defensive)
+─────────────────                      ──────────────────────────────
+ค้นหา vulnerabilities    ──handoff──►   สร้าง remediation plans
+สร้าง findings report                  IR playbooks, compliance mapping
+export handoff manifest                 executive summary
+```
+
+---
+
+## Support
+
+| ช่องทาง            | Link                                                                          |
+| ------------------ | ----------------------------------------------------------------------------- |
+| Installation Guide | [docs/INSTALL.md](docs/INSTALL.md)                                            |
+| Troubleshooting    | [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)                            |
+| Changelog          | [CHANGELOG.md](CHANGELOG.md)                                                  |
+| Report Issues      | [GitHub Issues](https://github.com/pitimon/claude-cybersecurity-skill/issues) |
+| Framework Updates  | [docs/FRAMEWORK-UPDATE-RUNBOOK.md](docs/FRAMEWORK-UPDATE-RUNBOOK.md)          |
+
+**Quick troubleshooting**:
 
 | ปัญหา                                | วิธีแก้                                                           |
 | ------------------------------------ | ----------------------------------------------------------------- |
@@ -628,26 +687,7 @@ claude-cybersecurity-skill/
 | Plugin ไม่แสดงหลังติดตั้ง            | ตรวจสอบชื่อ marketplace ใน 3 config files ต้องตรงกัน              |
 | Skill ไม่ trigger                    | Restart session (`/clear`) แล้วใช้ trigger keywords               |
 
-> ดูคู่มือแก้ไขปัญหาฉบับเต็ม: [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)
-
 ---
-
-## Related Plugins
-
-| Plugin                                                            | คำอธิบาย                                                                                                                                                                                                                                          | Install                                                 |
-| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| **[shannon-pentest](https://github.com/pitimon/shannon-pentest)** | Autonomous penetration testing orchestrator — configure targets, launch Docker-based multi-agent scans, monitor Temporal workflows, and analyze security findings. ใช้ร่วมกับ cybersecurity-pro เพื่อ remediation guidance หลังพบ vulnerabilities | `claude plugin install shannon-pentest@pitimon-shannon` |
-
-> **Complementary workflow**: Shannon ค้นหา vulnerabilities (offensive) → cybersecurity-pro สร้าง remediation plans, IR playbooks, compliance mapping (defensive)
-
----
-
-## Links
-
-- [Installation Guide](docs/INSTALL.md)
-- [Troubleshooting Guide](docs/TROUBLESHOOTING.md)
-- [Changelog](CHANGELOG.md)
-- [GitHub Issues](https://github.com/pitimon/claude-cybersecurity-skill/issues)
 
 ## License
 

--- a/skills/cybersecurity-pro/SKILL.md
+++ b/skills/cybersecurity-pro/SKILL.md
@@ -1,57 +1,15 @@
 ---
 name: cybersecurity-pro
 description: >
-  Generate professional cybersecurity documents: IR playbooks, DFIR forensic reports,
-  DevSecOps pipeline configs, SOC L1-L3 triage procedures, GitOps security policies,
-  code security analysis, container/supply chain security, compliance/threat modeling,
-  cloud security & CSPM, zero trust architecture, AI/ML security, API security,
-  vulnerability management, threat intelligence, cross-domain integration,
-  and security governance & executive leadership.
-  Use when asked about incident response, IR playbook, runbook, SOC triage, alert investigation,
-  threat hunting, digital forensics, malware analysis, DFIR, DevSecOps, SAST, DAST, SCA, SBOM,
-  CI/CD security, GitOps, security-as-code, vulnerability management, MITRE ATT&CK, NIST 800-61,
-  ISO 27035, OWASP, escalation workflow, forensic report, chain of custody, evidence handling,
-  log analysis, SIEM correlation, compliance reports, threat modeling, security architecture,
-  Semgrep, CodeQL, SARIF, variant analysis, code scanning, static analysis,
-  container security, Trivy, Grype, Dockerfile hardening, image scanning, supply chain, cosign, SLSA,
-  SOC 2, ISO 27001, GDPR, HIPAA, PCI-DSS, STRIDE, PASTA, risk assessment, PDPA,
-  NIST 800-53, CIS Controls, CIS Benchmarks, gap analysis, control mapping, compliance audit,
-  SOAR, security orchestration, automation, post-mortem,
-  cloud security, CSPM, AWS security, Azure security, GCP security, IAM policy, cloud misconfiguration,
-  Prowler, ScoutSuite, CSA CCM, NIST 800-144, CIS Cloud Benchmarks,
-  zero trust, ZTA, ZTNA, NIST 800-207, microsegmentation, SDP, never trust always verify,
-  CISA Zero Trust, conditional access,
-  AI security, LLM security, prompt injection, AI red team, MITRE ATLAS, AI governance,
-  model security, AI risk, EU AI Act, AI RMF, OWASP LLM Top 10, ML-BOM,
-  API security, OWASP API, BOLA, API gateway, rate limiting, JWT security, OAuth security,
-  API authentication, API inventory, API fuzzing, ความปลอดภัย API,
-  vulnerability management, CVSS, EPSS, KEV, patch management, vulnerability scan,
-  Nessus, Qualys, vulnerability prioritization, SSVC, การจัดการช่องโหว่,
-  threat intelligence, STIX, TAXII, IOC, indicator of compromise, threat feed,
-  MISP, OpenCTI, TLP, threat hunting, intelligence sharing, ข่าวกรองภัยคุกคาม,
-  cross-domain, integration, end-to-end, workflow, lifecycle, orchestration, security pipeline,
-  การบูรณาการ, cross-domain integration, multi-domain,
-  security governance, CISO, CAIO, CAISO, board reporting, cyber risk governance,
-  SEC disclosure, NIST CSF GOVERN, ISO 27014, C2M2, NACD, board oversight,
-  governance framework, security maturity, executive leadership, ธรรมาภิบาลความปลอดภัย,
-  OT security, ICS, SCADA, PLC, operational technology, NIST 800-82, IEC 62443,
-  Purdue model, industrial control, OT/IT convergence, ความปลอดภัย OT,
-  โครงสร้างพื้นฐานสำคัญ, DCS, RTU, HMI, Modbus, DNP3, OPC UA, BACnet,
-  NERC CIP, MITRE ATT&CK for ICS, OT incident response,
-  agentic AI, AI agent security, OWASP Agentic, ASI01, agent hijack, tool misuse,
-  agent orchestration, ความปลอดภัย AI Agent,
-  post-quantum, PQC, quantum cryptography, ML-KEM, ML-DSA, SLH-DSA, FIPS 203,
-  crypto-agility, CNSA 2.0, การเข้ารหัสควอนตัม,
-  identity security, IAM, FIDO2, passkeys, non-human identity, machine identity,
-  ITDR, identity governance, NIST 800-63, ความปลอดภัย Identity,
-  smart contract, Web3, blockchain security, DeFi, wallet security, Solidity,
-  OWASP Smart Contract, reentrancy, flash loan, ความปลอดภัย Blockchain,
-  การตอบสนองต่อเหตุการณ์, วิเคราะห์ภัยคุกคาม, ความปลอดภัยไซเบอร์, นิติวิทยาศาสตร์ดิจิทัล,
-  การวิเคราะห์ code, ความปลอดภัย container, การปฏิบัติตามกฎระเบียบ, การจำลองภัยคุกคาม,
-  ความปลอดภัยบนคลาวด์, สถาปัตยกรรม Zero Trust, ความปลอดภัย AI,
-  Shannon handoff, post-pentest defensive, ผล Shannon, defensive security documents,
-  สร้าง defensive docs จาก Shannon, handoff-manifest.
-  Outputs bilingual Thai+English documents mapped to NIST, MITRE ATT&CK, OWASP frameworks.
+  Use when asked to generate professional cybersecurity documents — IR
+  playbooks, DFIR forensic reports, SOC L1–L3 triage runbooks, DevSecOps
+  pipeline configs, threat models, compliance gap analyses, or executive
+  cyber-risk reports. Covers 22 domains across AppSec / Cloud / OT / AI-ML /
+  API / Identity / Web3, bilingual Thai+English output mapped to NIST 800-53,
+  MITRE ATT&CK, OWASP, ISO 27001. Also: post-pentest defensive (Shannon
+  handoff manifest). Triggers: "incident response", "SOC triage", "DFIR",
+  "threat hunt", "compliance audit", "การตอบสนองต่อเหตุการณ์",
+  "post-pentest defensive".
 user-invocable: true
 allowed-tools: Read, Grep, Glob, Write
 ---
@@ -59,7 +17,56 @@ allowed-tools: Read, Grep, Glob, Write
 # Cybersecurity Pro Skill
 
 สกิลระดับมืออาชีพสำหรับ Cybersecurity Operations ครอบคลุม 22 domains:
-IR, DFIR, DevSecOps, SOC+SOAR, GitOps, Code Security Analysis, Container & Supply Chain, Threat Modeling & Risk, Compliance Frameworks, Cloud Security & CSPM, Zero Trust Architecture, AI/ML Security, API Security, Vulnerability Management, Threat Intelligence, Cross-Domain Integration, Security Governance & Executive Leadership, OT/ICS Security
+IR, DFIR, DevSecOps, SOC+SOAR, GitOps, Code Security Analysis, Container & Supply Chain, Threat Modeling & Risk, Compliance Frameworks, Cloud Security & CSPM, Zero Trust Architecture, AI/ML Security, API Security, Vulnerability Management, Threat Intelligence, Cross-Domain Integration, Security Governance & Executive Leadership, OT/ICS Security, Agentic AI Security, Post-Quantum Cryptography, Identity & Access Security, Web3 & Blockchain Security
+
+## When This Skill Activates / เมื่อใดที่สกิลนี้ทำงาน
+
+This skill activates when prompts match any of the following trigger families. The list lives here in the body (not in the frontmatter description) to keep the per-entry description under Claude Code's 1536-character cap — Claude reads the body once the skill is invoked.
+
+**Incident Response & DFIR**
+incident response, IR playbook, runbook, SOC triage, alert investigation, threat hunting, digital forensics, malware analysis, DFIR, escalation workflow, forensic report, chain of custody, evidence handling, log analysis, SIEM correlation, post-mortem, SOAR, security orchestration, automation, MITRE ATT&CK, NIST 800-61, ISO 27035
+
+**DevSecOps & Code Security**
+DevSecOps, SAST, DAST, SCA, SBOM, CI/CD security, GitOps, security-as-code, OWASP, Semgrep, CodeQL, SARIF, variant analysis, code scanning, static analysis, CWE Top 25
+
+**Container & Supply Chain**
+container security, Trivy, Grype, Dockerfile hardening, image scanning, supply chain, cosign, SLSA, NIST 800-190
+
+**Compliance & Risk**
+compliance reports, threat modeling, security architecture, SOC 2, ISO 27001, GDPR, HIPAA, PCI-DSS, STRIDE, PASTA, risk assessment, PDPA, NIST 800-53, CIS Controls, CIS Benchmarks, gap analysis, control mapping, compliance audit
+
+**Cloud Security & CSPM**
+cloud security, CSPM, AWS security, Azure security, GCP security, IAM policy, cloud misconfiguration, Prowler, ScoutSuite, CSA CCM, NIST 800-144, CIS Cloud Benchmarks
+
+**Zero Trust**
+zero trust, ZTA, ZTNA, NIST 800-207, microsegmentation, SDP, never trust always verify, CISA Zero Trust, conditional access
+
+**AI/ML & Agentic AI**
+AI security, LLM security, prompt injection, AI red team, MITRE ATLAS, AI governance, model security, AI risk, EU AI Act, AI RMF, OWASP LLM Top 10, ML-BOM, agentic AI, AI agent security, OWASP Agentic, ASI01, agent hijack, tool misuse, agent orchestration, ความปลอดภัย AI Agent, ความปลอดภัย AI
+
+**API Security**
+API security, OWASP API, BOLA, API gateway, rate limiting, JWT security, OAuth security, API authentication, API inventory, API fuzzing, ความปลอดภัย API
+
+**Vulnerability Management & Threat Intelligence**
+vulnerability management, CVSS, EPSS, KEV, patch management, vulnerability scan, Nessus, Qualys, vulnerability prioritization, SSVC, การจัดการช่องโหว่, threat intelligence, STIX, TAXII, IOC, indicator of compromise, threat feed, MISP, OpenCTI, TLP, intelligence sharing, ข่าวกรองภัยคุกคาม
+
+**Cross-Domain & Governance**
+cross-domain, integration, end-to-end, workflow, lifecycle, orchestration, security pipeline, การบูรณาการ, multi-domain, security governance, CISO, CAIO, CAISO, board reporting, cyber risk governance, SEC disclosure, NIST CSF GOVERN, ISO 27014, C2M2, NACD, board oversight, governance framework, security maturity, executive leadership, ธรรมาภิบาลความปลอดภัย
+
+**OT/ICS**
+OT security, ICS, SCADA, PLC, operational technology, NIST 800-82, IEC 62443, Purdue model, industrial control, OT/IT convergence, ความปลอดภัย OT, โครงสร้างพื้นฐานสำคัญ, DCS, RTU, HMI, Modbus, DNP3, OPC UA, BACnet, NERC CIP, MITRE ATT&CK for ICS, OT incident response
+
+**Post-Quantum Cryptography**
+post-quantum, PQC, quantum cryptography, ML-KEM, ML-DSA, SLH-DSA, FIPS 203, crypto-agility, CNSA 2.0, การเข้ารหัสควอนตัม
+
+**Identity & Web3**
+identity security, IAM, FIDO2, passkeys, non-human identity, machine identity, ITDR, identity governance, NIST 800-63, ความปลอดภัย Identity, smart contract, Web3, blockchain security, DeFi, wallet security, Solidity, OWASP Smart Contract, reentrancy, flash loan, ความปลอดภัย Blockchain
+
+**Thai prompts**
+การตอบสนองต่อเหตุการณ์, วิเคราะห์ภัยคุกคาม, ความปลอดภัยไซเบอร์, นิติวิทยาศาสตร์ดิจิทัล, การวิเคราะห์ code, ความปลอดภัย container, การปฏิบัติตามกฎระเบียบ, การจำลองภัยคุกคาม, ความปลอดภัยบนคลาวด์, สถาปัตยกรรม Zero Trust
+
+**Post-pentest defensive (Shannon handoff)**
+Shannon handoff, post-pentest defensive, ผล Shannon, defensive security documents, สร้าง defensive docs จาก Shannon, handoff-manifest
 
 ## Language Policy / นโยบายภาษา
 


### PR DESCRIPTION
## Summary

- **Fixes #9** — `skills/cybersecurity-pro/SKILL.md` `description:` frontmatter trimmed from ~4,663 → **590 characters**, well under both Anthropic's spec cap (1024) and Claude Code's per-entry cap (`skillListingMaxDescChars` = 1536).
- Full trigger keyword list (15 categories) moved from the truncated frontmatter to the skill body under "When This Skill Activates / เมื่อใดที่สกิลนี้ทำงาน" — Claude reads the body once the skill is invoked anyway.
- README.md v4.0.2 rework — TOC, NIST CSF 2.0 coverage map, structured Support table, version bump.
- Version bumped to **4.0.2** in `plugin.json`, `marketplace.json`, `README.md`, plus CHANGELOG entry.

## Impact (per issue #9)

| Before | After |
|---|---|
| `/doctor`: warning on every session | clean |
| Trailing trigger keywords silently truncated | full list in body, all readable |
| ~15k tokens/session overhead if user raised cap | none |
| Risk Claude follows summary instead of full skill | spec-compliant (~580 chars, recommended ≤500) |

Description now follows Anthropic `writing-skills` guidance: starts with "Use when…", names concrete document types, lists representative triggers in both English and Thai.

## Test plan

- [x] `bash tests/validate-plugin.sh --skip-install-check` — **67 PASS / 0 FAIL** (2 advisory framework-staleness WARN unrelated to this PR)
- [x] Folded YAML description length verified at **590 chars** (under 1024 spec, under 1536 CC cap)
- [x] All 22 domain references still present in body
- [x] Trigger keywords preserved (now in body under "When This Skill Activates")
- [x] Version consistency across `plugin.json` / `marketplace.json` / `README.md` / CHANGELOG.md

Refs #9