### PR TITLE
chore: bump version to 4.0.3 (manifest reconciliation)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "cybersecurity-pro",
       "description": "Professional cybersecurity skill: 22 domains covering IR, DFIR, DevSecOps, SOC+SOAR, GitOps, Code Security, Container/Supply Chain, Threat Modeling, Compliance Frameworks, Cloud Security & CSPM, Zero Trust Architecture, AI/ML Security, API Security, Vulnerability Management, Threat Intelligence, Cross-Domain Integration, Security Governance & Executive Leadership, OT/ICS Security, Agentic AI Security, Post-Quantum Cryptography, Identity & Access Security, Web3 & Blockchain Security. Bilingual Thai+English output.",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "author": {
         "name": "P.Itarun"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cybersecurity-pro",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Professional cybersecurity skill: 22 domains covering IR, DFIR, DevSecOps, SOC+SOAR, GitOps, Code Security, Container/Supply Chain, Threat Modeling, Compliance Frameworks, Cloud Security & CSPM, Zero Trust Architecture, AI/ML Security, API Security, Vulnerability Management, Threat Intelligence, Cross-Domain Integration, Security Governance & Executive Leadership, OT/ICS Security, Agentic AI Security, Post-Quantum Cryptography, Identity & Access Security, and Web3 & Blockchain Security. Bilingual Thai+English output.",
   "author": {
     "name": "P.Itarun"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.2] - 2026-05-12
+## [4.0.3] - 2026-05-12
 
 ### Fixed
 
 - **SKILL.md description trimmed from ~4,663 → 590 characters** (#9) — within Anthropic spec cap (1024) and Claude Code per-entry cap (`skillListingMaxDescChars` = 1536). Eliminates `/doctor` warning, silent truncation of trailing trigger keywords, and ~15k tokens/session overhead for users who raised the cap. Full trigger keyword list (15 categories) moved to the skill body under "When This Skill Activates / เมื่อใดที่สกิลนี้ทำงาน" — Claude reads the body once the skill is invoked.
+- Version bump correction — v4.0.2 release tag/release on GitHub was created on 2026-03-01 for Issue #6 D19-D22 enhancements, but `plugin.json` / `marketplace.json` were not bumped at the time. This release reconciles the version files (4.0.1 → 4.0.3) so the manifest matches the latest tag.
 
 ### Changed
 
-- README.md rework — improved structure (TOC, NIST CSF coverage map, Frameworks badge, Related Plugins, Support table), Thai/English consistency pass, version bump to 4.0.2
+- README.md rework — improved structure (TOC, NIST CSF coverage map, Frameworks badge, Related Plugins, Support table), Thai/English consistency pass
 
 ## [4.0.0] - 2026-02-28
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Generate professional cybersecurity documents in 30 seconds — IR Playbooks, DF
 SOC Procedures, Compliance Audits, Cloud Security, AI Governance, OT/ICS, Post-Quantum Crypto,
 and 14 more domains — bilingual Thai + English output mapped to NIST, MITRE ATT&CK, OWASP, ISO frameworks
 
-[![Version](https://img.shields.io/badge/version-4.0.2-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-4.0.3-blue.svg)](CHANGELOG.md)
 [![CI](https://github.com/pitimon/claude-cybersecurity-skill/actions/workflows/validate.yml/badge.svg)](https://github.com/pitimon/claude-cybersecurity-skill/actions/workflows/validate.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Domains](https://img.shields.io/badge/domains-22-orange.svg)](#-22-security-domains)
@@ -31,7 +31,7 @@ and 14 more domains — bilingual Thai + English output mapped to NIST, MITRE AT
 - [See It in Action](#-see-it-in-action)
 - [Quick Start](#-quick-start)
 - [Why This Plugin](#-why-this-plugin)
-- [What's New in v4.0.2](#-whats-new-in-v402)
+- [What's New in v4.0.3](#-whats-new-in-v403)
 - [22 Security Domains](#-22-security-domains)
 - [NIST CSF 2.0 Coverage Map](#-nist-csf-20-coverage-map)
 - [Usage Examples](#-usage-examples)
@@ -148,7 +148,13 @@ claude doctor  # ตรวจสอบ version ใหม่
 
 ---
 
-## What's New in v4.0.2
+## What's New in v4.0.3
+
+**v4.0.3** — Skill description compliance + version reconciliation (Issue #9)
+
+- **SKILL.md description trimmed 4,663 → 590 chars** — เข้า cap ของ Anthropic spec (1024) และ Claude Code (`skillListingMaxDescChars` = 1536). แก้ `/doctor` warning, ป้องกัน truncation ของ trigger keywords และลด ~15k tokens/session overhead สำหรับ users ที่เปิด cap ไว้
+- **Trigger keywords moved to skill body** — 15 categories (Incident Response, DevSecOps, Cloud, AI/ML, OT/ICS, PQC, Identity, Web3, Thai prompts ฯลฯ) ภายใต้ section "When This Skill Activates / เมื่อใดที่สกิลนี้ทำงาน" — Claude อ่าน body ทุกครั้งที่ skill ถูก invoke อยู่แล้ว
+- **Version reconciliation** — `plugin.json` / `marketplace.json` (4.0.1 → 4.0.3) ให้ตรงกับ tag ล่าสุดที่ publish ไป (v4.0.2 issue #6 enhancements ที่ release Mar 1 ยังไม่ได้ bump manifest)
 
 **v4.0.2** — Issue #6 Enhancements (6 items)
 
@@ -567,7 +573,7 @@ Outputs อ้างอิง 73 frameworks จัดกลุ่มตาม au
 claude-cybersecurity-skill/
 ├── .claude-plugin/
 │   ├── marketplace.json              # Marketplace metadata
-│   └── plugin.json                   # Plugin manifest (v4.0.2)
+│   └── plugin.json                   # Plugin manifest (v4.0.3)
 ├── skills/
 │   └── cybersecurity-pro/
 │       ├── SKILL.md                  # Skill definition & decision tree (~500 lines)
@@ -621,7 +627,7 @@ claude-cybersecurity-skill/
 | **Plugin name** | `cybersecurity-pro`                       |
 | **Marketplace** | `pitimon-cybersecurity`                   |
 | **Install key** | `cybersecurity-pro@pitimon-cybersecurity` |
-| **Version**     | 4.0.2                                     |
+| **Version**     | 4.0.3                                     |
 | **Category**    | Security                                  |
 | **Author**      | P.Itarun                                  |
 | **Language**    | Bilingual Thai + English                  |


### PR DESCRIPTION
## Summary

Follow-up to #10. The tag \`v4.0.2\` was already published on **2026-03-01** for Issue #6 D19-D22 enhancements, but \`plugin.json\` / \`marketplace.json\` were never bumped at that time — they stayed at 4.0.1. PR #10's local bump to 4.0.2 collided with the published tag.

This bumps everything to **4.0.3** so the manifest matches the latest release tag. Issue #9 SKILL.md description trim (already merged in #10) ships under 4.0.3.

## Changes

| File | Before | After |
|---|---|---|
| \`.claude-plugin/plugin.json\` | 4.0.2 | 4.0.3 |
| \`.claude-plugin/marketplace.json\` | 4.0.2 | 4.0.3 |
| \`README.md\` (badge + TOC + What's New + structure tree + Project Info table) | 4.0.2 | 4.0.3 |
| \`CHANGELOG.md\` | 4.0.2 entry | 4.0.3 entry (documents version reconciliation) |

## Test plan

- [x] \`bash tests/validate-plugin.sh --skip-install-check\` — 67 PASS / 0 FAIL
- [x] No stray 4.0.2 refs outside intentional historical context (\`grep -rn "4\\.0\\.2"\`)
- [x] CHANGELOG explains the version-history gap

Refs #9